### PR TITLE
refactor(users): assert that every user has exactly one password field defined

### DIFF
--- a/modules/options/default.nix
+++ b/modules/options/default.nix
@@ -180,5 +180,13 @@ in
         to set `Permission.EnableAllFolders = false` for the user.
       '';
     }
+    {
+      assertion = all (
+        userOpts: (lib.count isNull [userOpts.password userOpts.hashedPassword userOpts.hashedPasswordFile]) == 2
+      ) (attrValues cfg.users);
+      message = ''
+        For a user, exactly one of `password`, `hashedPassword` and `hashedPasswordFile` should be defined.
+      '';
+    }
   ];
 }


### PR DESCRIPTION
This fixes #5. I have tested trying to define a user with no passwords set, and trying to define a user with more than one password set.