### PR TITLE
fix toPascalCase

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -78,7 +78,18 @@ with lib;
       fromAttrs' =
         f: x:
         if builtins.isAttrs x then
-          with lib.attrsets; mapAttrs' (name: value: nameValuePair (fromString name) (f value)) x
+          lib.attrsets.mapAttrs' (
+            name: value:
+            let
+              isReserved = lib.elem name [
+                "tag"
+                "content"
+                "attrib"
+              ];
+              newName = if isReserved then name else fromString name;
+            in
+            lib.attrsets.nameValuePair newName (f value)
+          ) x
         else if builtins.isList x then
           builtins.map f x
         else

--- a/modules/options/system.nix
+++ b/modules/options/system.nix
@@ -320,6 +320,7 @@ in
           content = {
             Name = "Jellyfin Stable";
             Url = "https://repo.jellyfin.org/files/plugin/manifest.json";
+            Enabled = true;
           };
         }
       ];

--- a/tests/autorun/to_pascal_case.nix
+++ b/tests/autorun/to_pascal_case.nix
@@ -44,8 +44,87 @@ in
               (genTest "snake case attribute set" {
                 SnakeCaseName = "snake_case_value";
               } (toPascalCase.fromAttrs { snake_case_name = "snake_case_value"; }))
-              # TODO: TODO
-              (genTest "recursive attret test" "TODO" "TODO")
+
+              # Ensures structural keys are preserved (tag/content/attrib),
+              # while inner data keys are PascalCased.
+              (genTest "preserve structural keys + pascalcase data"
+                {
+                  tag = "RepositoryInfo";
+                  content = {
+                    Name = "Jellyfin test";
+                    Url = "https://repo.jellyfin.org/files/plugin/manifest.json";
+                    Enabled = true;
+                  };
+                  attrib = {
+                    SomeAttr = "value";
+                  };
+                }
+                (
+                  toPascalCase.fromAttrsRecursive {
+                    tag = "RepositoryInfo";
+                    content = {
+                      name = "Jellyfin test";
+                      url = "https://repo.jellyfin.org/files/plugin/manifest.json";
+                      enabled = true;
+                    };
+                    attrib = {
+                      some_attr = "value";
+                    };
+                  }
+                )
+              )
+
+              # Sanity: a fully structured XML-like tree remains unchanged by renamer
+              # (no accidental Tag/Content/Attrib renames).
+              (genTest "no rename of structured xml nodes"
+                {
+                  tag = "PluginRepositories";
+                  content = [
+                    {
+                      tag = "RepositoryInfo";
+                      content = [
+                        {
+                          tag = "Name";
+                          content = "Jellyfin test";
+                        }
+                        {
+                          tag = "Url";
+                          content = "https://repo.jellyfin.org/files/plugin/manifest.json";
+                        }
+                        {
+                          tag = "Enabled";
+                          content = true;
+                        }
+                      ];
+                    }
+                  ];
+                }
+                (
+                  toPascalCase.fromAttrsRecursive {
+                    tag = "PluginRepositories";
+                    content = [
+                      {
+                        tag = "RepositoryInfo";
+                        content = [
+                          {
+                            tag = "Name";
+                            content = "Jellyfin test";
+                          }
+                          {
+                            tag = "Url";
+                            content = "https://repo.jellyfin.org/files/plugin/manifest.json";
+                          }
+                          {
+                            tag = "Enabled";
+                            content = true;
+                          }
+                        ];
+                      }
+                    ];
+                  }
+                )
+              )
+
               (genTest "attribute set with list"
                 {
                   List = [


### PR DESCRIPTION
Fixes https://github.com/Sveske-Juice/declarative-jellyfin/issues/11

<img width="2055" height="323" alt="image" src="https://github.com/user-attachments/assets/c0793693-811b-4607-877a-54503adc54ff" />

with the same test in the issue description,

`nix eval --raw .#hydraJobs.x86_64-linux.test`

```
{
  "content": [
    {
      "attrib": {
        "SomeAttr": "value"
      },
      "content": {
        "Enabled": true,
        "InnerList": [
          {
            "ListItem": "a"
          },
          {
            "ListItem": "b"
          }
        ],
        "Name": "Jellyfin test",
        "Url": "https://repo.jellyfin.org/files/plugin/manifest.json"
      },
      "tag": "RepositoryInfo"
    }
  ],
  "tag": "PluginRepositories"
}
```

`sudo cat /var/lib/jellyfin/config/system.xml`

```
  <PluginRepositories>
    <RepositoryInfo>
      <Name>Jellyfin Stable</Name>
      <Url>https://repo.jellyfin.org/files/plugin/manifest.json</Url>
      <Enabled>true</Enabled>
    </RepositoryInfo>
  </PluginRepositories>
```
