### PR TITLE
fix: split enableGroupingIntoCollections into two separate options

### DIFF
--- a/documentation/system.md
+++ b/documentation/system.md
@@ -118,8 +118,15 @@ Whether to enable .
 
 **Default**: `false`
 
-## system.enableGroupingIntoCollections
-Whether to enable .
+## system.enableGroupingMoviesIntoCollections
+Whether to enable Automatically group movies into collections.
+
+**Type**: boolean
+
+**Default**: `false`
+
+## system.enableGroupingShowsIntoCollections
+Whether to enable Automatically group shows into collections.
 
 **Type**: boolean
 

--- a/modules/options/system.nix
+++ b/modules/options/system.nix
@@ -302,7 +302,9 @@ in {
 
     enableFolderView = mkEnableOption "";
 
-    enableGroupingIntoCollections = mkEnableOption "";
+    enableGroupingMoviesIntoCollections = mkEnableOption "Automatically group movies into collections";
+
+    enableGroupingShowsIntoCollections = mkEnableOption "Automatically group shows into collections";
 
     displaySpecialsWithinSeasons = mkOption {
       type = types.bool;


### PR DESCRIPTION
## Summary

This PR fixes the `enableGroupingIntoCollections` option by splitting it into two separate options that match Jellyfin's actual XML structure.

## Changes

- Replace single `enableGroupingIntoCollections` option with:
  - `enableGroupingMoviesIntoCollections` - Automatically group movies into collections
  - `enableGroupingShowsIntoCollections` - Automatically group shows into collections
- Updated documentation automatically via generate-documentation

## Motivation

Jellyfin's `system.xml` actually has two separate settings:
- `<EnableGroupingMoviesIntoCollections>`
- `<EnableGroupingShowsIntoCollections>`

The previous single option `enableGroupingIntoCollections` was **not functional** because it didn't match Jellyfin's actual configuration structure. This meant users could not properly configure collection grouping behavior.

This PR fixes the issue by providing two separate options that correctly map to Jellyfin's XML configuration.