### PR TITLE
Add missing encoding options

### DIFF
--- a/documentation/encoding.md
+++ b/documentation/encoding.md
@@ -125,6 +125,16 @@ https://jellyfin.org/docs/general/administration/hardware-acceleration/intel/#co
 
 **Default**: `false`
 
+## encoding.enableEnhancedNvdecDecoder
+Enhanced NVDEC implementation, disable this option to use CUVID if you encounter decoding errors.
+
+https://jellyfin.org/docs/general/post-install/transcoding/hardware-acceleration/nvidia#tone-mapping-methods
+.
+
+**Type**: booleann
+
+**Default**: `false`
+
 ## encoding.preferSystemNativeHwDecoder
 Prefer OS native DXVA or VA-API hardware decoders
 

--- a/modules/options/encoding.nix
+++ b/modules/options/encoding.nix
@@ -332,6 +332,11 @@ with lib; {
 
       https://jellyfin.org/docs/general/administration/hardware-acceleration/intel/#configure-and-verify-lp-mode-on-linux
     '';
+    enableEnhancedNvdecDecoder = mkEnableOption ''
+      Enhanced NVDEC implementation, disable this option to use CUVID if you encounter decoding errors.
+
+      https://jellyfin.org/docs/general/post-install/transcoding/hardware-acceleration/nvidia#tone-mapping-methods
+    '';
     preferSystemNativeHwDecoder = mkEnableOption ''
       Prefer OS native DXVA or VA-API hardware decoders
 


### PR DESCRIPTION
Adds `encoding.preferSystemNativeHwDecoder` and `encoding.enableEnhancedNvdecDecoder`.