### PR TITLE
feat: Support 10.11.7

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -45,11 +45,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1772198003,
-        "narHash": "sha256-I45esRSssFtJ8p/gLHUZ1OUaaTaVLluNkABkk6arQwE=",
+        "lastModified": 1775036866,
+        "narHash": "sha256-ZojAnPuCdy657PbTq5V0Y+AHKhZAIwSIT2cb8UgAz/U=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "dd9b079222d43e1943b6ebd802f04fd959dc8e61",
+        "rev": "6201e203d09599479a3b3450ed24fa81537ebc4e",
         "type": "github"
       },
       "original": {

--- a/modules/config.nix
+++ b/modules/config.nix
@@ -10,6 +10,7 @@ with lib; let
     "10.11.4"
     "10.11.5"
     "10.11.6"
+    "10.11.7"
   ];
   cfg = config.services.declarative-jellyfin;
   genhash = import ./pbkdf2-sha512.nix {inherit pkgs;};


### PR DESCRIPTION
## Summary

- Add `10.11.7` to `supportedVersions` in `modules/config.nix`
- Update `flake.lock` to nixpkgs `6201e203` (2026-04-01) which includes jellyfin/jellyfin-web 10.11.7

## Test plan

- [x] CI tests pass with jellyfin 10.11.7